### PR TITLE
fix: Add sharp dependency to fix Netlify build error

### DIFF
--- a/robovestx-unified/package.json
+++ b/robovestx-unified/package.json
@@ -31,7 +31,8 @@
     "dotenv": "^16.3.1",
     "express-rate-limit": "^6.7.0",
     "winston": "^3.10.0",
-    "winston-daily-rotate-file": "^4.7.1"
+    "winston-daily-rotate-file": "^4.7.1",
+    "sharp": "^0.32.1"
   },
   "devDependencies": {
     "eslint": "^8",


### PR DESCRIPTION
This commit adds the `sharp` dependency to the `package.json` file. This is necessary to fix a build error on Netlify, as Next.js 13.4.7 and later versions have an implicit dependency on the `sharp` package for image optimization.